### PR TITLE
MacOSX WatchService check for null file in recursiveListFiles

### DIFF
--- a/src/main/java/com/barbarysoftware/watchservice/MacOSXListeningWatchService.java
+++ b/src/main/java/com/barbarysoftware/watchservice/MacOSXListeningWatchService.java
@@ -110,10 +110,12 @@ class MacOSXListeningWatchService extends AbstractWatchService {
 
     private static Set<File> recursiveListFiles(File file) {
         Set<File> files = new HashSet<File>();
-        files.add(file);
-        if (file.isDirectory()) {
-            for (File child : file.listFiles()) {
-                files.addAll(recursiveListFiles(child));
+        if (file != null) {
+            files.add(file);
+            if (file.isDirectory()) {
+                for (File child : file.listFiles()) {
+                    files.addAll(recursiveListFiles(child));
+                }
             }
         }
         return files;


### PR DESCRIPTION
It's possible to have listFiles return a null in specific conditions (I believe if the directory is deleted).
This code should check for that before using the file variable.
